### PR TITLE
Fix to prevent upper case UUIDs being stored for threadIds

### DIFF
--- a/RelayServiceKit/src/Contacts/TSThread.m
+++ b/RelayServiceKit/src/Contacts/TSThread.m
@@ -589,7 +589,7 @@ NSString *const TSThread_NotificationKey_UniqueId = @"TSpThread_NotificationKey_
     }];
     
     if (thread == nil) {
-        thread = [TSThread getOrCreateThreadWithId:[[NSUUID UUID] UUIDString] transaction:transaction];
+        thread = [TSThread getOrCreateThreadWithId:[[NSUUID UUID] UUIDString].lowercaseString transaction:transaction];
         thread.participantIds = [participantIDs copy];
 //        [thread saveWithTransaction:transaction];
     }

--- a/RelayServiceKit/src/Storage/TSYapDatabaseObject.m
+++ b/RelayServiceKit/src/Storage/TSYapDatabaseObject.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init
 {
-    return [self initWithUniqueId:[[NSUUID UUID] UUIDString]];
+    return [self initWithUniqueId:[[NSUUID UUID] UUIDString].lowercaseString];
 }
 
 - (instancetype)initWithUniqueId:(NSString *_Nullable)aUniqueId


### PR DESCRIPTION
Fix to prevent upper case UUIDs being stored for threadIds