### PR TITLE
Tweak web preview to only trip on strings containing http

### DIFF
--- a/Relay/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Relay/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -148,7 +148,9 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
                 
                 if ([match resultType] == NSTextCheckingTypeLink) {
                     NSString *aString = match.URL.absoluteString;
-                    _urlString = [aString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"];
+                    if ([aString containsString:@"http://"] || [aString containsString:@"https://"]) {
+                        _urlString = [aString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"];
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Make sure the web page preview only appears for web pages.